### PR TITLE
Run composerInstall after copyExtension

### DIFF
--- a/build.js
+++ b/build.js
@@ -49,9 +49,10 @@ function buildGeneral(options = {}) {
     }
 
     if (helpers.hasProcessParam('copy')) {
-        copyExtension().then(() => {
-            setOwner().then(() => console.log('Done'));
-        });
+        copyExtension()
+        .then(() => setOwner())
+        .then(() => composerInstall())
+        .then(() => console.log('Done'));
     }
     if (helpers.hasProcessParam('after-install')) {
         afterInstall().then(() => console.log('Done'));


### PR DESCRIPTION
Running `node build --copy` removes the `vendor` directory from the extension's root directory. This forces the developer to run `node build --composer-install` after running `node build --copy` each time. Running the steps together probably makes more sense. This is related to #3.